### PR TITLE
Add proto3 specific deserialization that requires fewer SRTP constrai…

### DIFF
--- a/Serialization.Test/ExampleProtoClass.fs
+++ b/Serialization.Test/ExampleProtoClass.fs
@@ -108,13 +108,13 @@ module SampleNamespace =
         member m.Serialize zcb                  = Serialize.toZeroCopyBuffer m zcb
         member m.SerializeLengthDelimited ()    = Serialize.toArrayLD m
 
-        static member Deserialize buf                   = buf |> Deserialize.fromArray (InnerMessage())
-        static member Deserialize buf                   = buf |> Deserialize.fromArraySegment (InnerMessage())
-        static member Deserialize zcb                   = zcb |> Deserialize.fromZeroCopyBuffer (InnerMessage())
-        static member Deserialize raw                   = raw |> Deserialize.fromRawField (InnerMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArrayLD (InnerMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArraySegmentLD (InnerMessage())
-        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.fromZcbLD (InnerMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArray (InnerMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArraySegment (InnerMessage())
+        static member Deserialize zcb                   = zcb |> Deserialize.Proto2.fromZeroCopyBuffer (InnerMessage())
+        static member Deserialize raw                   = raw |> Deserialize.Proto2.fromRawField (InnerMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArrayLD (InnerMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArraySegmentLD (InnerMessage())
+        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.Proto2.fromZcbLD (InnerMessage())
                 
 
 
@@ -158,7 +158,7 @@ module PerformanceTest =
             let zcr = Froto.Serialization.ZeroCopyBuffer(zcw.Array)
             seq {
                 while not zcr.IsEof do
-                    yield zcr |> Deserialize.fromZcbLD (InnerMessage())
+                    yield zcr |> Deserialize.Proto2.fromZcbLD (InnerMessage())
             }
 
         ys |> Seq.iter ignore

--- a/Serialization.Test/ExampleProtoRecord.fs
+++ b/Serialization.Test/ExampleProtoRecord.fs
@@ -115,7 +115,7 @@ module PerformanceTest =
             let zcr = Froto.Serialization.ZeroCopyBuffer(zcw.Array)
             seq {
                 while not zcr.IsEof do
-                    yield zcr |> Deserialize.fromZcbLD InnerSample.Default
+                    yield zcr |> Deserialize.Proto2.fromZcbLD InnerSample.Default
             }
 
         ys |> Seq.iter ignore

--- a/Serialization.Test/TestClassSerialization.fs
+++ b/Serialization.Test/TestClassSerialization.fs
@@ -53,13 +53,13 @@ module ClassSerialization =
         member m.Serialize zcb                  = Serialize.toZeroCopyBuffer m zcb
         member m.SerializeLengthDelimited ()    = Serialize.toArrayLD m
 
-        static member Deserialize buf                   = buf |> Deserialize.fromArray (InnerMessage())
-        static member Deserialize buf                   = buf |> Deserialize.fromArraySegment (InnerMessage())
-        static member Deserialize zcb                   = zcb |> Deserialize.fromZeroCopyBuffer (InnerMessage())
-        static member Deserialize raw                   = raw |> Deserialize.fromRawField (InnerMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArrayLD (InnerMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArraySegmentLD (InnerMessage())
-        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.fromZcbLD (InnerMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArray (InnerMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArraySegment (InnerMessage())
+        static member Deserialize zcb                   = zcb |> Deserialize.Proto2.fromZeroCopyBuffer (InnerMessage())
+        static member Deserialize raw                   = raw |> Deserialize.Proto2.fromRawField (InnerMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArrayLD (InnerMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArraySegmentLD (InnerMessage())
+        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.Proto2.fromZcbLD (InnerMessage())
 
 
     [<Fact>]
@@ -155,13 +155,13 @@ module ClassSerialization =
         member m.Serialize zcb                  = Serialize.toZeroCopyBuffer m zcb
         member m.SerializeLengthDelimited ()    = Serialize.toArrayLD m
 
-        static member Deserialize buf                   = buf |> Deserialize.fromArray (OuterMessage())
-        static member Deserialize buf                   = buf |> Deserialize.fromArraySegment (OuterMessage())
-        static member Deserialize zcb                   = zcb |> Deserialize.fromZeroCopyBuffer (OuterMessage())
-        static member Deserialize raw                   = raw |> Deserialize.fromRawField (OuterMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArrayLD (OuterMessage())
-        static member DeserializeLengthDelimited buf    = buf |> Deserialize.fromArraySegmentLD (OuterMessage())
-        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.fromZcbLD (OuterMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArray (OuterMessage())
+        static member Deserialize buf                   = buf |> Deserialize.Proto2.fromArraySegment (OuterMessage())
+        static member Deserialize zcb                   = zcb |> Deserialize.Proto2.fromZeroCopyBuffer (OuterMessage())
+        static member Deserialize raw                   = raw |> Deserialize.Proto2.fromRawField (OuterMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArrayLD (OuterMessage())
+        static member DeserializeLengthDelimited buf    = buf |> Deserialize.Proto2.fromArraySegmentLD (OuterMessage())
+        static member DeserializeLengthDelimited zcb    = zcb |> Deserialize.Proto2.fromZcbLD (OuterMessage())
 
 
     [<Fact>]

--- a/Serialization/Serialization.fs
+++ b/Serialization/Serialization.fs
@@ -18,19 +18,28 @@
 ///
 ///    <c>Serializer : (m:^T, ZeroCopyBuffer) -> ZeroCopyBuffer</c>
 ///
-/// Deserializable types must provide, at minimum, the following static
+/// For proto2 Deserializable types must provide, at minimum, the following static
 /// methods.
 ///
 ///     * DecoderRing   - maps FieldId to a deserialization function
 ///     * RememberFound - adds a FieldId to list of found fields
 ///     * DecodeFixup   - called after decoding the message
-///     * RequiredFields- list of (proto2) required fields; can be empty
+///     * RequiredFields- list of required fields; can be empty
 ///     * FoundFields   - returns list of fields found
-///     * UnknownFields - returns list of unknown fields
 ///
-/// These can be associated with any valid F# type, including Records and
-/// Classes, because the serialization functions use Static Type Constraints
-/// to locate these static methods.
+/// If you are using proto3 Deserializable types then you must provide, 
+/// at minimum, the following static methods.
+///
+///     * DecoderRing   - maps FieldId to a deserialization function
+///     * DecodeFixup   - called after decoding the message
+///
+/// The Proto3 module should be used to deserialize rather than functions inside
+/// the Deserialize module e.g. 
+///    <c>Deserialise.Proto3.fromArray message.Default bytes</c>
+///
+/// The static methods mentioned above can be associated with any valid F# type, 
+/// including Records and Classes, because the serialization functions use
+/// Static Type Constraints to locate these static methods.
 ///
 /// <c>DecoderRing : Map &lt; int, 'T -> RawField -> 'T &gt;</c>
 ///
@@ -165,125 +174,265 @@ module Serialize =
 module Deserialize =
 
     module Helpers =
-
-        let inline decodeFixup (m:^msg) =
-            (^msg : (static member DecodeFixup : ^msg -> ^msg) (m) )
-
-        let inline deserializeFields m fields =
-
-            let inline decoderRing (m:^msg) =
-                (^msg : (static member DecoderRing: Map<int,^msg -> RawField -> ^msg>) () )
+        module Proto2 =    
+            let inline deserializeFields m fields =
     
-            let inline requiredFields (m:^msg) =
-                (^msg : (static member RequiredFields: Set<FieldNum>) () )
-
-            let inline foundFields (m:^msg) =
-                (^msg : (static member FoundFields: ^msg -> Set<FieldNum>) (m) )
-
-            let inline rememberFound (m:^msg) fieldNum =
-                (^msg : (static member RememberFound : ^msg -> FieldNum -> ^msg) (m,fieldNum) )
-
-            let inline fetchDecoder decoderRing (field:RawField) =
-                let decode decoder m (rawField:RawField) =
-                    let m = rememberFound m (rawField.FieldNum)
-                    in decoder m rawField
-
-                let n = field.FieldNum
-                match decoderRing |> Map.tryFind n with
-                | Some(decoder) -> (decode decoder, field)
-                | None ->
-                    match decoderRing |> Map.tryFind 0 with
+                let inline decoderRing (m:^msg) =
+                    (^msg : (static member DecoderRing: Map<int,^msg -> RawField -> ^msg>) () )
+        
+                let inline requiredFields (m:^msg) =
+                    (^msg : (static member RequiredFields: Set<FieldNum>) () )
+    
+                let inline foundFields (m:^msg) =
+                    (^msg : (static member FoundFields: ^msg -> Set<FieldNum>) (m) )
+    
+                let inline rememberFound (m:^msg) fieldNum =
+                    (^msg : (static member RememberFound : ^msg -> FieldNum -> ^msg) (m,fieldNum) )
+    
+                let inline fetchDecoder decoderRing (field:RawField) =
+                    let decode decoder m (rawField:RawField) =
+                        let m = rememberFound m (rawField.FieldNum)
+                        in decoder m rawField
+    
+                    let n = field.FieldNum
+                    match decoderRing |> Map.tryFind n with
                     | Some(decoder) -> (decode decoder, field)
                     | None ->
-                        raise <| SerializerException(sprintf "Invalid decoder ring; encountered unknown field '%d' and ring must include an entry for field number 0 to handle unknown fields" n)
-
-            /// decode a sequence of fields, given a decoder ring and a default or mutable message.
-            /// Note that a List would perform slightly better, but demand more memory during operation.
-            let inline decode decoderRing m fields =
-                fields
-                |> Seq.map (fetchDecoder decoderRing)
-                |> Seq.fold (fun acc (fn, fld) -> fn acc fld) m
-
-
-            let m = decode (decoderRing m) m fields
-            let missingFields = (requiredFields m) - (foundFields m)
-            if Set.isEmpty missingFields
-            then
+                        match decoderRing |> Map.tryFind 0 with
+                        | Some(decoder) -> (decode decoder, field)
+                        | None ->
+                            raise <| SerializerException(sprintf "Invalid decoder ring; encountered unknown field '%d' and ring must include an entry for field number 0 to handle unknown fields" n)
+    
+                /// decode a sequence of fields, given a decoder ring and a default or mutable message.
+                /// Note that a List would perform slightly better, but demand more memory during operation.
+                let inline decode decoderRing m fields =
+                    fields
+                    |> Seq.map (fetchDecoder decoderRing)
+                    |> Seq.fold (fun acc (fn, fld) -> fn acc fld) m
+    
+    
+                let m = decode (decoderRing m) m fields
+                let missingFields = (requiredFields m) - (foundFields m)
+                if Set.isEmpty missingFields
+                then
+                    m
+                else
+                    raise <| SerializerException(sprintf "Missing required fields %A" missingFields)
+                
+        module Proto3 =
+            let inline deserializeFields m fields =
+    
+                let inline decoderRing (m:^msg) =
+                    (^msg : (static member DecoderRing: Map<int,^msg -> RawField -> ^msg>) () )
+    
+                let inline fetchDecoder decoderRing (field:RawField) =
+                    let decode decoder m (rawField:RawField) =
+                        decoder m rawField
+    
+                    let n = field.FieldNum
+                    match decoderRing |> Map.tryFind n with
+                    | Some(decoder) -> (decode decoder, field)
+                    | None ->
+                        match decoderRing |> Map.tryFind 0 with
+                        | Some(decoder) -> (decode decoder, field)
+                        //No action for unknown fields in proto3 if there is no supplied field mapping
+                        | None -> (fun m _ -> m), field 
+                    
+                /// decode a sequence of fields, given a decoder ring and a default or mutable message.
+                /// Note that a List would perform slightly better, but demand more memory during operation.
+                let inline decode decoderRing m fields =
+                    fields
+                    |> Seq.map (fetchDecoder decoderRing)
+                    |> Seq.fold (fun acc (fn, fld) -> fn acc fld) m
+    
+                let m = decode (decoderRing m) m fields
                 m
-            else
-                raise <| SerializerException(sprintf "Missing required fields %A" missingFields)
 
-    /// Deserialize a message from a ZeroCopyBuffer, given a default message.
-    let inline fromZeroCopyBuffer m zcb =
-        zcb
-        |> Utility.decodeBuffer
-        |> Helpers.deserializeFields m
-        |> Helpers.decodeFixup
-
-    /// Deserialize a message from a ZeroCopyBuffer, given a default message.
-    /// Shorthand for Deserialize.fromZeroCopyBuffer.
-    let inline fromZcb m zcb = fromZeroCopyBuffer m zcb
-
-    /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
-    let inline fromZeroCopyBufferLengthDelimited m zcb =
-        zcb
-        |> Utility.unpackLengthDelimited
-        |> Helpers.deserializeFields m
-        |> Helpers.decodeFixup
-
-    /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
-    /// Shorthand for Deserialize.fromZeroCopyBufferLengthDelimited.
-    let inline fromZcbLD m zcb = fromZeroCopyBufferLengthDelimited m zcb
-
-    /// Deserialize a message from a length-delimited RawField, given a default message.
-    let inline fromRawField m (rawField:RawField) =
-        let buf = 
-            match rawField with
-            | LengthDelimited (fieldId, buf) ->
-                buf
-            | _ ->
-                raise <| SerializerException(sprintf "Expected LengthDelimited field, found %s" (rawField.GetType().Name) )
-        buf
-        |> ZeroCopyBuffer
-        |> fromZeroCopyBuffer m
-
-    /// Deserialize a message from a length-delimited RawField, given a default message,
-    /// and return Some(message).  Used to simplify the call-site when deserializing
-    /// inner messages.
-    let inline optionalMessage m rawField =
-        Some (fromRawField m rawField)
-
-    /// Deserialize a message from an ArraySegment, given a default message.
-    let inline fromArraySegment m (buf:ArraySegment<byte>) =
-        buf
-        |> ZeroCopyBuffer
-        |> fromZcb m
-
-    /// Deserialize a length-delimited message from an ArraySegment, given a default message.
-    let inline fromArraySegmentLengthDelimited m (buf:ArraySegment<byte>) =
-        buf
-        |> ZeroCopyBuffer
-        |> fromZcbLD m
-
-    /// Deserialize a length-delimited message from an ArraySegment, given a default message.
-    /// Shorthand for Deserialize.fromArraySegmentLengthDelimited.
-    let inline fromArraySegmentLD m buf = fromArraySegmentLengthDelimited m buf
-
-    /// Deserialize a message from a byte array, given a default message.
-    let inline fromArray m buf =
-        buf
-        |> ArraySegment
-        |> fromArraySegment m
-
-    /// Deserialize a length-delimited message from a byte array, given a default message.
-    let inline fromArrayLengthDelimited m buf =
-        buf
-        |> ArraySegment
-        |> fromArraySegmentLD m
-
-    /// Deserialize a length-delimited message from a byte array, given a default message.
-    /// Shorthand for Deserialize.fromArrayLengthDelimited.
-    let inline fromArrayLD m buf = fromArrayLengthDelimited m buf
-
-
-
+    module Shared =
+    
+        let inline decodeFixup (m:^msg) =
+            (^msg : (static member DecodeFixup : ^msg -> ^msg) (m) )
+                    
+        /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+        let inline fromZeroCopyBuffer deserializer m zcb =
+            zcb
+            |> Utility.decodeBuffer
+            |> deserializer m
+            |> decodeFixup
+    
+        /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+        /// Shorthand for Deserialize.fromZeroCopyBuffer.
+        let inline fromZcb m zcb = fromZeroCopyBuffer m zcb
+    
+        /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+        let inline fromZeroCopyBufferLengthDelimited deserializer m zcb =
+            zcb
+            |> Utility.unpackLengthDelimited
+            |> deserializer m
+            |> decodeFixup
+    
+        /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+        /// Shorthand for Deserialize.fromZeroCopyBufferLengthDelimited.
+        let inline fromZcbLD deserializer m zcb = fromZeroCopyBufferLengthDelimited deserializer m zcb
+    
+        /// Deserialize a message from a length-delimited RawField, given a default message.
+        let inline fromRawField deserializer m (rawField:RawField) =
+            let buf = 
+                match rawField with
+                | LengthDelimited (fieldId, buf) ->
+                    buf
+                | _ ->
+                    raise <| SerializerException(sprintf "Expected LengthDelimited field, found %s" (rawField.GetType().Name) )
+            buf
+            |> ZeroCopyBuffer
+            |> fromZeroCopyBuffer deserializer m
+    
+        /// Deserialize a message from a length-delimited RawField, given a default message,
+        /// and return Some(message).  Used to simplify the call-site when deserializing
+        /// inner messages.
+        let inline optionalMessage deserializer m rawField =
+            Some (fromRawField deserializer m rawField)
+    
+        /// Deserialize a message from an ArraySegment, given a default message.
+        let inline fromArraySegment deserializer m (buf:ArraySegment<byte>) =
+            buf
+            |> ZeroCopyBuffer
+            |> fromZcb deserializer m
+    
+        /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+        let inline fromArraySegmentLengthDelimited deserializer m (buf:ArraySegment<byte>) =
+            buf
+            |> ZeroCopyBuffer
+            |> fromZcbLD deserializer m
+    
+        /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+        /// Shorthand for Deserialize.fromArraySegmentLengthDelimited.
+        let inline fromArraySegmentLD deserializer m buf = fromArraySegmentLengthDelimited deserializer m buf
+    
+        /// Deserialize a message from a byte array, given a default message.
+        let inline fromArray deserializer m buf =
+            buf
+            |> ArraySegment
+            |> fromArraySegment deserializer m
+    
+        /// Deserialize a length-delimited message from a byte array, given a default message.
+        let inline fromArrayLengthDelimited deserializer m buf =
+            buf
+            |> ArraySegment
+            |> fromArraySegmentLD deserializer m
+    
+        /// Deserialize a length-delimited message from a byte array, given a default message.
+        /// Shorthand for Deserialize.fromArrayLengthDelimited.
+        let inline fromArrayLD deserializer m buf = fromArrayLengthDelimited deserializer m buf
+        
+    module Proto2 =
+        open Helpers.Proto2
+        /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+        let inline fromZeroCopyBuffer m zcb =
+            Shared.fromZeroCopyBuffer deserializeFields m zcb
+    
+        /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+        /// Shorthand for Deserialize.fromZeroCopyBuffer.
+        let inline fromZcb m zcb =
+            Shared.fromZeroCopyBuffer deserializeFields m zcb
+    
+        /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+        let inline fromZeroCopyBufferLengthDelimited m zcb =
+            Shared.fromZeroCopyBufferLengthDelimited deserializeFields m zcb
+           
+        /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+        /// Shorthand for Deserialize.fromZeroCopyBufferLengthDelimited.
+        let inline fromZcbLD m zcb =
+            Shared.fromZeroCopyBufferLengthDelimited deserializeFields m zcb
+    
+        /// Deserialize a message from a length-delimited RawField, given a default message.
+        let inline fromRawField m (rawField:RawField) =
+            Shared.fromRawField deserializeFields m rawField
+    
+        /// Deserialize a message from a length-delimited RawField, given a default message,
+        /// and return Some(message).  Used to simplify the call-site when deserializing
+        /// inner messages.
+        let inline optionalMessage m rawField =
+            Shared.optionalMessage deserializeFields m rawField
+    
+        /// Deserialize a message from an ArraySegment, given a default message.
+        let inline fromArraySegment m (buf:ArraySegment<byte>) =
+            Shared.fromArraySegment deserializeFields m buf
+    
+        /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+        let inline fromArraySegmentLengthDelimited m (buf:ArraySegment<byte>) =
+            Shared.fromArraySegmentLengthDelimited deserializeFields m buf
+    
+        /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+        /// Shorthand for Deserialize.fromArraySegmentLengthDelimited.
+        let inline fromArraySegmentLD m buf =
+            Shared.fromArraySegmentLengthDelimited deserializeFields m buf
+    
+        /// Deserialize a message from a byte array, given a default message.
+        let inline fromArray m buf =
+            Shared.fromArray deserializeFields m buf
+    
+        /// Deserialize a length-delimited message from a byte array, given a default message.
+        let inline fromArrayLengthDelimited m buf =
+            Shared.fromArrayLengthDelimited deserializeFields m buf
+    
+        /// Deserialize a length-delimited message from a byte array, given a default message.
+        /// Shorthand for Deserialize.fromArrayLengthDelimited.
+        let inline fromArrayLD m buf =
+            Shared.fromArrayLengthDelimited deserializeFields m buf
+    
+    module Proto3 =
+         open Helpers.Proto3
+         /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+         let inline fromZeroCopyBuffer m zcb =
+             Shared.fromZeroCopyBuffer deserializeFields m zcb
+     
+         /// Deserialize a message from a ZeroCopyBuffer, given a default message.
+         /// Shorthand for Deserialize.fromZeroCopyBuffer.
+         let inline fromZcb m zcb =
+             Shared.fromZeroCopyBuffer deserializeFields m zcb
+     
+         /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+         let inline fromZeroCopyBufferLengthDelimited m zcb =
+             Shared.fromZeroCopyBufferLengthDelimited deserializeFields m zcb
+            
+         /// Deserialize a length-delimited message from a ZeroCopyBuffer, given a default message.
+         /// Shorthand for Deserialize.fromZeroCopyBufferLengthDelimited.
+         let inline fromZcbLD m zcb =
+             Shared.fromZeroCopyBufferLengthDelimited deserializeFields m zcb
+     
+         /// Deserialize a message from a length-delimited RawField, given a default message.
+         let inline fromRawField m (rawField:RawField) =
+             Shared.fromRawField deserializeFields m rawField
+     
+         /// Deserialize a message from a length-delimited RawField, given a default message,
+         /// and return Some(message).  Used to simplify the call-site when deserializing
+         /// inner messages.
+         let inline optionalMessage m rawField =
+             Shared.optionalMessage deserializeFields m rawField
+     
+         /// Deserialize a message from an ArraySegment, given a default message.
+         let inline fromArraySegment m (buf:ArraySegment<byte>) =
+             Shared.fromArraySegment deserializeFields m buf
+     
+         /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+         let inline fromArraySegmentLengthDelimited m (buf:ArraySegment<byte>) =
+             Shared.fromArraySegmentLengthDelimited deserializeFields m buf
+     
+         /// Deserialize a length-delimited message from an ArraySegment, given a default message.
+         /// Shorthand for Deserialize.fromArraySegmentLengthDelimited.
+         let inline fromArraySegmentLD m buf =
+             Shared.fromArraySegmentLengthDelimited deserializeFields m buf
+     
+         /// Deserialize a message from a byte array, given a default message.
+         let inline fromArray m buf =
+             Shared.fromArray deserializeFields m buf
+     
+         /// Deserialize a length-delimited message from a byte array, given a default message.
+         let inline fromArrayLengthDelimited m buf =
+             Shared.fromArrayLengthDelimited deserializeFields m buf
+     
+         /// Deserialize a length-delimited message from a byte array, given a default message.
+         /// Shorthand for Deserialize.fromArrayLengthDelimited.
+         let inline fromArrayLD m buf =
+             Shared.fromArrayLengthDelimited deserializeFields m buf


### PR DESCRIPTION
…nts (#85)

* Add proto3 specific deserialization that requires fewer SRTP constraints
* Refactor to share as much as possible between proto2/3 deserialization
* Fix tests to refere to proto2 on deserialize
* Removed UnknownFields from the xmldoc
* A property named UnknownFields is not required by SRTP constraints
* Use the 0 field mapping for unknown fields if present, no action if this is missing.
    - This gives the code generator the choice of generating the 0 field maping to a property, therefore adhering to the proto3.5 chanages to make implementation preserve unknown fields on deserialisation.
* Add unit tests for proto3
* Remove unecessary RequiredFields
* Add some documentation about proto3 definitions
* preserve any previous unknown fields on re-serialization